### PR TITLE
adds full list of modENCODE.

### DIFF
--- a/bin/alignment.snake
+++ b/bin/alignment.snake
@@ -42,9 +42,8 @@ with open('../data/312_sample_golden_set_2016-06-14.txt', 'r') as fh:
 with open('../data/13495_runs_analyzed_by_mieg.txt', 'r') as fh:
     mieg = [x.strip() for x in fh.readlines()]
 
-# modEncode SRRs (644)
-with open('../data/modEncode_srrs.txt', 'r') as fh:
-    modEncode = [x.strip() for x in fh.readlines()]
+# modEncode SRRs (2,312)
+modEncode = pd.read_csv('../output/modENCODE_sampletable.tsv', sep='\t').srr.unique().tolist()
 
 # s2 SRRs
 with open('../data/1508_s2_cell_brian_annot.txt', 'r') as fh:

--- a/bin/pre-prealignment.snake
+++ b/bin/pre-prealignment.snake
@@ -55,9 +55,8 @@ with open('../data/312_sample_golden_set_2016-06-14.txt', 'r') as fh:
 with open('../data/13495_runs_analyzed_by_mieg.txt', 'r') as fh:
     mieg = [x.strip() for x in fh.readlines()]
 
-# modEncode SRRs (644)
-with open('../data/modEncode_srrs.txt', 'r') as fh:
-    modEncode = [x.strip() for x in fh.readlines()]
+# modEncode SRRs (2,312)
+modEncode = pd.read_csv('../output/modENCODE_sampletable.tsv', sep='\t').srr.unique().tolist()
 
 # s2 cells (1508)
 with open('../data/1508_s2_cell_brian_annot.txt', 'r') as fh:
@@ -76,7 +75,7 @@ samples = remap.aggregate([
     {'$unwind': '$runs'},
     {'$match': {
         'runs.srr': {'$exists': 1},
-        'runs.srr': {'$in': priority},
+        'runs.srr': {'$in': modEncode},
         '$or': [
                 {'runs.pre_aln_flags': {'$exists': 0}},
                 {'runs.pre_aln_flags': {'$eq': []}},

--- a/bin/prealignment.snake
+++ b/bin/prealignment.snake
@@ -81,9 +81,8 @@ with open('../data/312_sample_golden_set_2016-06-14.txt', 'r') as fh:
 with open('../data/13495_runs_analyzed_by_mieg.txt', 'r') as fh:
     mieg = [x.strip() for x in fh.readlines()]
 
-# modEncode SRRs (644)
-with open('../data/modEncode_srrs.txt', 'r') as fh:
-    modEncode = [x.strip() for x in fh.readlines()]
+# modEncode SRRs (2,312)
+modEncode = pd.read_csv('../output/modENCODE_sampletable.tsv', sep='\t').srr.unique().tolist()
 
 # s2 SRRs
 with open('../data/1104_s2_cell_in_mieg.txt', 'r') as fh:
@@ -102,7 +101,7 @@ samples = remap.aggregate([
         '$match': {
             '$and': [
                 {'runs.srr': {'$exists': 1}},
-                {'runs.srr': {'$in': priority}},
+                {'runs.srr': {'$in': modEncode}},
                 {'runs.libsize.R1': {'$exists': 1}},
                 {'runs.pre_aln_flags': {'$ne': 'complete'}},
                 {'runs.pre_aln_flags': {'$ne': 'download_bad'}},


### PR DESCRIPTION
### What does it do?
- Updates the  list of modENCODE samples to include all seq experiments (2,312).