### PR TITLE
Replaced other with OTHER.

### DIFF
--- a/library_strategy-wf/scripts/munge_strategy_and_selection_from_mongo.py
+++ b/library_strategy-wf/scripts/munge_strategy_and_selection_from_mongo.py
@@ -10,7 +10,7 @@ def main():
                 [{"$project": {"_id": 0, "srx": 1, "library_strategy": 1, "library_selection": 1}}]
             )
         )
-    ).set_index("srx")
+    ).set_index("srx").replace({"other": "OTHER"})
 
     df.to_parquet(snakemake.output.data)
 


### PR DESCRIPTION
There is a submission that uses "other" instead of "OTHER".
I add a step to normalize to "OTHER" for both strategy and selection.
