### PR TITLE
Change to use parquet format instead of tsv.

### DIFF
--- a/library_strategy-wf/Snakefile
+++ b/library_strategy-wf/Snakefile
@@ -34,23 +34,11 @@ select_library_strategy
 """
 rule targets:
     input:
-        "../output/library_strategy-wf/summarized_metadata.parquet",
-        "../output/library_strategy-wf/umap_prealn_features_embeddings.tsv",
-        "../output/library_strategy-wf/pca_prealn_features_embeddings.tsv",
+        "../output/library_strategy-wf/pca_prealn_features_embeddings.parquet",
+        "../output/library_strategy-wf/prealn_outliers.parquet",
         "../output/library_strategy-wf/library_strategy.svg",
         "../output/library_strategy-wf/library_selection.svg",
-
-
-rule free_text_library_strategy:
-    output: "../output/library_strategy-wf/free_text_library_strategy.parquet"
-    script: "scripts/free_text_library_strategy.py"
-
-
-rule munge_strategy_and_selection_from_mongo:
-    output:
-        data="../output/library_strategy-wf/sra_strategy_selection.parquet",
-        summary="../output/library_strategy-wf/sra_strategy_selection_summary_table.tsv",
-    script: "scripts/munge_strategy_and_selection_from_mongo.py"
+        "../output/library_strategy-wf/summarized_metadata.parquet",
 
 
 rule build_prealn_feature_set:
@@ -61,6 +49,7 @@ rule build_prealn_feature_set:
     output: "../output/library_strategy-wf/prealn_feature_set.parquet"
     script: "scripts/build_prealn_feature_set.py"
 
+
 rule scale_feature_set:
     input: rules.build_prealn_feature_set.output[0]
     output: "../output/library_strategy-wf/scaled_prealn_feature_set.parquet"
@@ -70,18 +59,25 @@ rule scale_feature_set:
 rule pca_prealn_feature_set:
     input: rules.scale_feature_set.output[0]
     output: 
-        embeddings="../output/library_strategy-wf/pca_prealn_features_embeddings.tsv",
-        loadings="../output/library_strategy-wf/pca_prealn_features_loadings.tsv",
-        variance="../output/library_strategy-wf/pca_prealn_features_explained_variance.tsv",
+        embeddings="../output/library_strategy-wf/pca_prealn_features_embeddings.parquet",
+        loadings="../output/library_strategy-wf/pca_prealn_features_loadings.parquet",
+        variance="../output/library_strategy-wf/pca_prealn_features_explained_variance.parquet",
     script: "scripts/pca_prealn_feature_set.py"
 
 
 rule umap_prealn_feature_set:
     input: rules.scale_feature_set.output[0]
     output: 
-        embeddings="../output/library_strategy-wf/umap_prealn_features_embeddings.tsv",
+        embeddings="../output/library_strategy-wf/umap_prealn_features_embeddings.parquet",
         model="../output/library_strategy-wf/umap_prealn_features_model.joblib.pkl"
     script: "scripts/umap_prealn_feature_set.py"
+
+
+rule munge_strategy_and_selection_from_mongo:
+    output:
+        data="../output/library_strategy-wf/sra_strategy_selection.parquet",
+        summary="../output/library_strategy-wf/sra_strategy_selection_summary_table.tsv",
+    script: "scripts/munge_strategy_and_selection_from_mongo.py"
 
 
 rule panel_plots:
@@ -112,6 +108,11 @@ rule random_forest:
         feature_importance="../output/library_strategy-wf/random_forest_feature_importance.tsv",
         predicted_labels="../output/library_strategy-wf/random_forest_predicted_labels.parquet"
     script: "scripts/random_forest.py"
+
+
+rule free_text_library_strategy:
+    output: "../output/library_strategy-wf/free_text_library_strategy.parquet"
+    script: "scripts/free_text_library_strategy.py"
 
 
 rule metadata_integration:

--- a/library_strategy-wf/scripts/panel_plots.py
+++ b/library_strategy-wf/scripts/panel_plots.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         snakemake = snakemake_debug(
             input=dict(
                 labels="../../output/library_strategy-wf/sra_strategy_selection.parquet",
-                umap="../../output/library_strategy-wf/umap_prealn_features_embeddings.tsv",
+                umap="../../output/library_strategy-wf/umap_prealn_features_embeddings.parquet",
             ),
             output=dict(strategy="", selection=""),
         )

--- a/library_strategy-wf/scripts/pca_prealn_feature_set.py
+++ b/library_strategy-wf/scripts/pca_prealn_feature_set.py
@@ -21,9 +21,9 @@ def main():
         reducer.explained_variance_ratio_, index=component_names, columns=["explained_variance"]
     )
 
-    embeddings.to_csv(snakemake.output.embeddings, sep="\t")
-    loadings.to_csv(snakemake.output.loadings, sep="\t")
-    explained_variance.to_csv(snakemake.output.variance, sep="\t")
+    embeddings.to_parquet(snakemake.output.embeddings)
+    loadings.to_parquet(snakemake.output.loadings)
+    explained_variance.to_parquet(snakemake.output.variance)
 
 
 if __name__ == "__main__":

--- a/library_strategy-wf/scripts/umap_prealn_feature_set.py
+++ b/library_strategy-wf/scripts/umap_prealn_feature_set.py
@@ -17,7 +17,7 @@ def main():
 
     # save
     joblib.dump(reducer, snakemake.output.model)
-    df.to_csv(snakemake.output.embeddings, sep="\t")
+    df.to_parquet(snakemake.output.embeddings)
 
 
 if __name__ == "__main__":

--- a/src/ncbi_remap/plotting/umap_panel.py
+++ b/src/ncbi_remap/plotting/umap_panel.py
@@ -51,7 +51,7 @@ class Plot(NcbiPlotter):
 
     def get_data(self):
         labels = pd.read_parquet(self.labels_file)
-        embeddings = pd.read_table(self.embeddings_file, index_col=0)
+        embeddings = pd.read_parquet(self.embeddings_file)
 
         self.embedding_columns = embeddings.columns
         self.data = (


### PR DESCRIPTION
### What does it do?
- Changes to use parquet instead of TSV.

I am using TSV in the paper workflow, but other workflows it is easier to use parquet format.