### PR TITLE
RNA-Seq Workflow Migration.

### DIFF
--- a/migration/prealn-wf_featurecounts.py
+++ b/migration/prealn-wf_featurecounts.py
@@ -55,7 +55,7 @@ def check_log(file_name):
 
 def get_counts(file_name):
     col_name = pd.read_table(file_name, comment="#", nrows=1).columns[-1]
-    return pd.read_table(file_name, comment="#", usecols=[col_name], dtype=np.int64).values
+    return pd.read_table(file_name, comment="#", usecols=[col_name], dtype=np.uint32).values
 
 
 def parse_table(files):

--- a/migration/rnaseq-wf_aln_stats.py
+++ b/migration/rnaseq-wf_aln_stats.py
@@ -1,0 +1,74 @@
+import sys
+from pathlib import Path
+from collections import namedtuple
+
+import pandas as pd
+
+sys.path.insert(0, "../src")
+from ncbi_remap.parser import parse_bamtools_stats, parse_samtools_stats
+
+
+RNASEQ_PATH = Path("../output/rnaseq-wf/samples")
+
+Files = namedtuple("Files", "srx idx idxstats samtools bamtools output")
+
+
+def main():
+    for srx_pth in RNASEQ_PATH.iterdir():
+        if not srx_pth.is_dir():
+            continue
+        srx = srx_pth.name
+        files = Files(
+            srx,
+            pd.Index([srx], name="srx"),
+            (srx_pth / f"{srx}.bam.samtools.idxstats"),
+            (srx_pth / f"{srx}.bam.samtools.stats"),
+            (srx_pth / f"{srx}.bam.bamtools.stats"),
+            f"../output/rnaseq-wf/aln_stats/{srx}.parquet",
+        )
+
+        if files.samtools.exists() and files.bamtools.exists():
+            if files.samtools.stat().st_size > 0 and files.bamtools.stat().st_size > 0:
+                convert_table(files)
+            else:
+                print(files.samtools, files.bamtools)
+
+            files.samtools.unlink()
+            files.bamtools.unlink()
+
+        if files.idxstats.exists():
+            files.idxstats.unlink()
+
+
+def convert_table(files):
+    try:
+        df = pd.concat([_samtools(files.samtools), _bamtools(files.bamtools)], axis=1, sort=False)
+        df.index = pd.Index([files.srx], name="srx")
+        df.to_parquet(files.output)
+    except Exception as e:
+        print(files.samtools)
+        print(files.bamtools)
+        raise e
+
+
+def _samtools(file_name):
+    return parse_samtools_stats(file_name)[
+        [
+            "reads_MQ0",
+            "average_quality",
+            "insert_size_average",
+            "insert_size_standard_deviation",
+            "inward_oriented_pairs",
+            "outward_oriented_pairs",
+            "pairs_with_other_orientation",
+            "pairs_on_different_chromosomes",
+        ]
+    ]
+
+
+def _bamtools(file_name):
+    return parse_bamtools_stats(file_name)[["Percent Forward", "Percent Reverse"]]
+
+
+if __name__ == "__main__":
+    main()

--- a/migration/rnaseq-wf_aln_stats.py
+++ b/migration/rnaseq-wf_aln_stats.py
@@ -1,5 +1,4 @@
 import sys
-import os
 from pathlib import Path
 from collections import namedtuple
 
@@ -9,7 +8,6 @@ sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_bamtools_stats, parse_samtools_stats
 
 
-CLEAN_UP = os.environ.get("CLEAN_UP", False)
 RNASEQ_PATH = Path("../output/rnaseq-wf/samples")
 
 Files = namedtuple("Files", "srx idx idxstats samtools bamtools output")
@@ -34,14 +32,6 @@ def main():
                 convert_table(files)
             else:
                 print(files.samtools, files.bamtools)
-
-            if CLEAN_UP:
-                files.samtools.unlink()
-                files.bamtools.unlink()
-
-        if files.idxstats.exists():
-            if CLEAN_UP:
-                files.idxstats.unlink()
 
 
 def convert_table(files):

--- a/migration/rnaseq-wf_aln_stats.py
+++ b/migration/rnaseq-wf_aln_stats.py
@@ -1,4 +1,5 @@
 import sys
+import os
 from pathlib import Path
 from collections import namedtuple
 
@@ -8,7 +9,7 @@ sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_bamtools_stats, parse_samtools_stats
 
 
-CLEAN_UP = False
+CLEAN_UP = os.environ.get("CLEAN_UP", False)
 RNASEQ_PATH = Path("../output/rnaseq-wf/samples")
 
 Files = namedtuple("Files", "srx idx idxstats samtools bamtools output")

--- a/migration/rnaseq-wf_aln_stats.py
+++ b/migration/rnaseq-wf_aln_stats.py
@@ -8,6 +8,7 @@ sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_bamtools_stats, parse_samtools_stats
 
 
+CLEAN_UP = False
 RNASEQ_PATH = Path("../output/rnaseq-wf/samples")
 
 Files = namedtuple("Files", "srx idx idxstats samtools bamtools output")
@@ -33,11 +34,13 @@ def main():
             else:
                 print(files.samtools, files.bamtools)
 
-            files.samtools.unlink()
-            files.bamtools.unlink()
+            if CLEAN_UP:
+                files.samtools.unlink()
+                files.bamtools.unlink()
 
         if files.idxstats.exists():
-            files.idxstats.unlink()
+            if CLEAN_UP:
+                files.idxstats.unlink()
 
 
 def convert_table(files):

--- a/migration/rnaseq-wf_atropos.py
+++ b/migration/rnaseq-wf_atropos.py
@@ -1,3 +1,4 @@
+import os
 import re
 from collections import namedtuple
 from pathlib import Path
@@ -5,7 +6,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-CLEAN_UP = False
+CLEAN_UP = os.environ.get("CLEAN_UP", False)
 RNASEQ_PATH = Path("../output/rnaseq-wf/samples")
 DTYPES = {
     "total_processed": np.int64,

--- a/migration/rnaseq-wf_atropos.py
+++ b/migration/rnaseq-wf_atropos.py
@@ -1,0 +1,99 @@
+import re
+import shutil
+from collections import namedtuple
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+RNASEQ_PATH = Path("../output/rnaseq-wf/samples")
+DTYPES = {
+    "total_processed": np.int64,
+    "total_written": np.int64,
+    "too_short": np.int64,
+}
+
+Files = namedtuple("Files", "srr idx table log output")
+
+
+class AtroposException(Exception):
+    """Basic exception when there are problems running Atropos"""
+
+
+def main():
+    for srr_pth in RNASEQ_PATH.glob("**/SRR*"):
+        if not srr_pth.is_dir():
+            continue
+        srr = srr_pth.name
+        files = Files(
+            srr,
+            pd.Index([srr], name="srr"),
+            (srr_pth / f"{srr}.trim.clean.tsv"),
+            (srr_pth / f"{srr}_1.trim.clean.fastq.gz.log"),
+            f"../output/rnaseq-wf/atropos/{srr}.parquet",
+        )
+
+        if files.table.exists():
+            convert_tsv(files)
+        elif files.log.exists():
+            convert_log(files)
+ 
+    rnaseq_dir_cleanup()
+
+
+def convert_tsv(files):
+    df = pd.read_table(files.table)[DTYPES.keys()].fillna(0).astype(DTYPES)
+    df.index = files.idx
+    df.to_parquet(files.output)
+    files.table.unlink()
+    files.log.unlink()
+
+
+def convert_log(files):
+    try:
+        df = pd.DataFrame([parse_atropos(files.log)], index=files.idx, columns=DTYPES.keys())
+        df.to_parquet(files.output)
+
+        if df.total_written[0] < 1000:
+            raise AtroposException(
+                "Too few reads after Atropos: %d (%s)", df.total_written[0], files.log
+            )
+
+    except AtroposException:
+        print(f"Problems with Atropos: {files.log}")
+        atropos_bad_path = Path(f"../output/rnaseq-wf/atropos_bad")
+        atropos_bad_path.mkdir(exist_ok=True)
+        (atropos_bad_path / files.srr).touch()
+
+    files.log.unlink()
+
+
+def parse_atropos(file_name):
+    with open(file_name) as fh:
+        string = fh.read().replace(",", "")
+
+    if "ERROR" in string:
+        raise AtroposException("Problem with Atropos: %s", file_name)
+
+    try:
+        tot_processed = int(re.findall(r"Total read.*processed:\s+(\d+)", string)[0])
+        tot_written = int(
+            re.findall(r"[Read|Pair]s written \(passing filters\):\s+(\d+)", string)[0]
+        )
+        too_short = int(re.findall(r"[Read|Pair]s that were too short:\s+(\d+)", string)[0])
+        return tot_processed, tot_written, too_short
+    except IndexError:
+        raise AtroposException("Problem with Atropos: %s", file_name)
+
+
+def rnaseq_dir_cleanup():
+    srrs = set([pth.name for pth in Path("../output/rnaseq-wf/atropos_bad").iterdir()])
+    for pth in Path("../output/rnaseq-wf/samples/").glob("**/SRR*"):
+        if pth.name in srrs:
+            for file_pth in pth.iterdir():
+                if not "fastq_screen" in file_pth.name:
+                    file_pth.unlink()
+
+
+if __name__ == "__main__":
+    main()

--- a/migration/rnaseq-wf_atropos.py
+++ b/migration/rnaseq-wf_atropos.py
@@ -1,11 +1,11 @@
 import re
-import shutil
 from collections import namedtuple
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 
+CLEAN_UP = False
 RNASEQ_PATH = Path("../output/rnaseq-wf/samples")
 DTYPES = {
     "total_processed": np.int64,
@@ -45,8 +45,9 @@ def convert_tsv(files):
     df = pd.read_table(files.table)[DTYPES.keys()].fillna(0).astype(DTYPES)
     df.index = files.idx
     df.to_parquet(files.output)
-    files.table.unlink()
-    files.log.unlink()
+    if CLEAN_UP:
+        files.table.unlink()
+        files.log.unlink()
 
 
 def convert_log(files):
@@ -65,7 +66,8 @@ def convert_log(files):
         atropos_bad_path.mkdir(exist_ok=True)
         (atropos_bad_path / files.srr).touch()
 
-    files.log.unlink()
+    if CLEAN_UP:
+        files.log.unlink()
 
 
 def parse_atropos(file_name):
@@ -91,7 +93,7 @@ def rnaseq_dir_cleanup():
     for pth in Path("../output/rnaseq-wf/samples/").glob("**/SRR*"):
         if pth.name in srrs:
             for file_pth in pth.iterdir():
-                if not "fastq_screen" in file_pth.name:
+                if not "fastq_screen" in file_pth.name and CLEAN_UP:
                     file_pth.unlink()
 
 

--- a/migration/rnaseq-wf_bigwig.py
+++ b/migration/rnaseq-wf_bigwig.py
@@ -1,7 +1,8 @@
+import os
 from pathlib import Path
 import shutil
 
-CLEAN_UP = False
+CLEAN_UP = os.environ.get("CLEAN_UP", False)
 
 def main():
     for srx_pth in Path("../output/rnaseq-wf/samples").iterdir():
@@ -24,12 +25,17 @@ def main():
 def move(first: Path, second: Path, dir_name: str):
     output_path = Path("../output/rnaseq-wf") / dir_name
     output_path.mkdir(exist_ok=True)
-    if CLEAN_UP:
-        shutil.move(first, output_path / first.name)
-        shutil.move(second, output_path / second.name)
+    first_out = output_path / first.name
+    second_out = output_path / second.name
+
+    if first.exists() and second.exists() and CLEAN_UP:
+        shutil.move(first, first_out)
+        shutil.move(second, second_out)
+    elif first.exists() and second.exists():
+        print(first, "-->", first_out)
+        print(second, "-->", second_out)
     else:
-        print(first, "-->", output_path / first.name)
-        print(second, "-->", output_path / second.name)
+        print("Missing:", first, second, sep="\t")
 
 
 if __name__ == "__main__":

--- a/migration/rnaseq-wf_bigwig.py
+++ b/migration/rnaseq-wf_bigwig.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import shutil
+
+CLEAN_UP = False
+
+def main():
+    for srx_pth in Path("../output/rnaseq-wf/samples").iterdir():
+        if not srx_pth.is_dir():
+            continue
+
+        srx = srx_pth.name
+
+        # UCSC
+        first = srx_pth / f"{srx}.first.bw"
+        second = srx_pth / f"{srx}.second.bw"
+        move(first, second, "ucsc_bigwigs")
+
+        # FlyBase
+        first = srx_pth / f"{srx}.flybase.first.bw"
+        second = srx_pth / f"{srx}.flybase.second.bw"
+        move(first, second, "flybase_bigwigs")
+
+
+def move(first: Path, second: Path, dir_name: str):
+    output_path = Path("../output/rnaseq-wf") / dir_name
+    output_path.mkdir(exist_ok=True)
+    if CLEAN_UP:
+        shutil.move(first, output_path / first.name)
+        shutil.move(second, output_path / second.name)
+    else:
+        print(first, "-->", output_path / first.name)
+        print(second, "-->", output_path / second.name)
+
+
+if __name__ == "__main__":
+    main()

--- a/migration/rnaseq-wf_cleanup.py
+++ b/migration/rnaseq-wf_cleanup.py
@@ -1,0 +1,106 @@
+import os
+import re
+import shutil
+from pathlib import Path
+
+SRR_PATTERN = re.compile(r"^[SED]RR\d+$")
+CLEAN_UP = os.environ.get("CLEAN_UP", False)
+
+
+def main():
+    for srx_path in Path("../output/rnaseq-wf/samples").iterdir():
+        srx = srx_path.name
+        remove_temp(srx)
+
+        if (
+            Path(f"../output/rnaseq-wf/atropos_bad/{srx}").exists()
+            or Path(f"../output/rnaseq-wf/alignment_bad/{srx}").exists()
+        ):
+            remove_srx_folder(srx)
+            continue
+
+        if (
+            Path(f"../output/rnaseq-wf/aln_stats/{srx}.parquet").exists()
+            & Path(f"../output/rnaseq-wf/gene_counts/{srx}.parquet").exists()
+            & Path(f"../output/rnaseq-wf/junction_counts/{srx}.parquet").exists()
+            & Path(f"../output/rnaseq-wf/intergenic_counts/{srx}.parquet").exists()
+            & Path(f"../output/rnaseq-wf/segment_counts/{srx}.parquet").exists()
+            & Path(f"../output/rnaseq-wf/fusion_counts/{srx}.parquet").exists()
+            & Path(f"../output/rnaseq-wf/flybase_bigwigs/{srx}.flybase.first.bw").exists()
+            & Path(f"../output/rnaseq-wf/flybase_bigwigs/{srx}.flybase.second.bw").exists()
+            & Path(f"../output/rnaseq-wf/ucsc_bigwigs/{srx}.first.bw").exists()
+            & Path(f"../output/rnaseq-wf/ucsc_bigwigs/{srx}.second.bw").exists()
+            & Path(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam").exists()
+            & Path(f"../output/rnaseq-wf/samples/{srx}/{srx}.bai").exists()
+        ):
+            Path(f"../output/rnaseq-wf/done/{srx}").touch()
+            remove_srr_folders(srx)
+            remove_processed_files(srx)
+            remove_misc_files(srx)
+
+
+def remove_temp(srx: str):
+    for pth in Path(f"../output/rnaseq-wf/samples/{srx}").glob("*.tmp"):
+        pth.unlink()
+
+
+def remove_srx_folder(srx: str):
+    pth = Path(f"../output/rnaseq-wf/samples/{srx}")
+    if pth.exists() and CLEAN_UP:
+        shutil.rmtree(pth)
+    elif pth.exists():
+        print("Removing SRX Folder:", pth, sep="\t")
+
+
+def remove_srr_folders(srx: str):
+    for pth in Path(f"../output/rnaseq-wf/samples/{srx}").iterdir():
+        if pth.is_dir() and re.match(SRR_PATTERN, pth.name):
+            if CLEAN_UP:
+                shutil.rmtree(pth)
+            else:
+                print("Removing SRR Folder:", pth, sep="\t")
+
+
+def remove_file(file_name: str):
+    pth = Path(file_name)
+    if pth.exists() and CLEAN_UP:
+        pth.unlink()
+    elif pth.exists():
+        print("Removing File:", pth, sep="\t")
+
+
+def remove_processed_files(srx: str):
+
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.samtools.stats")
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.bamtools.stats")
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.counts")
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.counts.jcounts")
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.intergenic.counts")
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.exon_fusions.counts")
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.exon_segments.counts")
+
+
+def remove_misc_files(srx: str):
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.trim.clean.tsv")
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.hisat2.bam.tsv")
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.samtools.idxstats")
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.counts")
+
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.counts.summary")
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.counts.log")
+
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.intergenic.counts.jcounts")
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.intergenic.counts.summary")
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.intergenic.counts.log")
+
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.exon_fusions.counts.jcounts")
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.exon_fusions.counts.summary")
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.exon_fusions.counts.log")
+
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.exon_segments.counts.jcounts")
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.exon_segments.counts.summary")
+    remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.exon_segments.counts.log")
+
+
+if __name__ == "__main__":
+    main()

--- a/migration/rnaseq-wf_cleanup.py
+++ b/migration/rnaseq-wf_cleanup.py
@@ -3,8 +3,22 @@ import re
 import shutil
 from pathlib import Path
 
-SRR_PATTERN = re.compile(r"^[SED]RR\d+$")
 CLEAN_UP = os.environ.get("CLEAN_UP", False)
+SRR_PATTERN = re.compile(r"^[SED]RR\d+$")
+TARGETS = [
+    "../output/rnaseq-wf/aln_stats/{srx}.parquet",
+    "../output/rnaseq-wf/gene_counts/{srx}.parquet",
+    "../output/rnaseq-wf/junction_counts/{srx}.parquet",
+    "../output/rnaseq-wf/intergenic_counts/{srx}.parquet",
+    "../output/rnaseq-wf/segment_counts/{srx}.parquet",
+    "../output/rnaseq-wf/fusion_counts/{srx}.parquet",
+    "../output/rnaseq-wf/flybase_bigwigs/{srx}.flybase.first.bw",
+    "../output/rnaseq-wf/flybase_bigwigs/{srx}.flybase.second.bw",
+    "../output/rnaseq-wf/ucsc_bigwigs/{srx}.first.bw",
+    "../output/rnaseq-wf/ucsc_bigwigs/{srx}.second.bw",
+    "../output/rnaseq-wf/samples/{srx}/{srx}.bam",
+    "../output/rnaseq-wf/samples/{srx}/{srx}.bam.bai",
+]
 
 
 def main():
@@ -19,20 +33,7 @@ def main():
             remove_srx_folder(srx)
             continue
 
-        if (
-            Path(f"../output/rnaseq-wf/aln_stats/{srx}.parquet").exists()
-            & Path(f"../output/rnaseq-wf/gene_counts/{srx}.parquet").exists()
-            & Path(f"../output/rnaseq-wf/junction_counts/{srx}.parquet").exists()
-            & Path(f"../output/rnaseq-wf/intergenic_counts/{srx}.parquet").exists()
-            & Path(f"../output/rnaseq-wf/segment_counts/{srx}.parquet").exists()
-            & Path(f"../output/rnaseq-wf/fusion_counts/{srx}.parquet").exists()
-            & Path(f"../output/rnaseq-wf/flybase_bigwigs/{srx}.flybase.first.bw").exists()
-            & Path(f"../output/rnaseq-wf/flybase_bigwigs/{srx}.flybase.second.bw").exists()
-            & Path(f"../output/rnaseq-wf/ucsc_bigwigs/{srx}.first.bw").exists()
-            & Path(f"../output/rnaseq-wf/ucsc_bigwigs/{srx}.second.bw").exists()
-            & Path(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam").exists()
-            & Path(f"../output/rnaseq-wf/samples/{srx}/{srx}.bai").exists()
-        ):
+        if all(check_target(target.format(srx=srx)) for target in TARGETS):
             Path(f"../output/rnaseq-wf/done/{srx}").touch()
             remove_srr_folders(srx)
             remove_processed_files(srx)
@@ -50,6 +51,12 @@ def remove_srx_folder(srx: str):
         shutil.rmtree(pth)
     elif pth.exists():
         print("Removing SRX Folder:", pth, sep="\t")
+
+
+def check_target(file_name: str):
+    if Path(file_name).exists():
+        return True
+    print("Missing Target:", file_name, sep="\t")
 
 
 def remove_srr_folders(srx: str):
@@ -70,9 +77,9 @@ def remove_file(file_name: str):
 
 
 def remove_processed_files(srx: str):
-
     remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.samtools.stats")
     remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.bamtools.stats")
+
     remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.counts")
     remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.counts.jcounts")
     remove_file(f"../output/rnaseq-wf/samples/{srx}/{srx}.bam.intergenic.counts")

--- a/migration/rnaseq-wf_fusion_counts.py
+++ b/migration/rnaseq-wf_fusion_counts.py
@@ -1,5 +1,7 @@
 import sys
 from pathlib import Path
+from collections import namedtuple
+from multiprocessing import Pool
 
 import numpy as np
 import pandas as pd
@@ -7,41 +9,47 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
+Files = namedtuple("Files", "srx file_name output")
+
 
 def main():
+    workers = Pool(24)
+    work = []
     for srx_pth in Path("../output/rnaseq-wf/samples").iterdir():
+        srx = srx_pth.name
         if not srx_pth.is_dir():
             continue
 
-        srx = srx_pth.name
-        file_name = srx_pth / f"{srx}.bam.exon_fusions.counts"
-        output = f"../output/rnaseq-wf/fusion_counts/{srx}.parquet"
+        files = Files(
+            srx,
+            srx_pth / f"{srx}.bam.exon_fusions.counts",
+            f"../output/rnaseq-wf/fusion_counts/{srx}.parquet"
+        )
 
-        if not file_name.exists():
-            continue
+        if files.file_name.exists():
+            work.append(files)
 
-        try:
-            # Check if file is from feature counts or is already parsed.
-            with file_name.open() as fh:
-                data = fh.read(10)
-
-            if data.startswith("#"):
-                df = parse_featureCounts_counts(file_name, srx)
-            else:
-                df = parse_table(file_name, srx)
-
-            df.to_parquet(output)
-            file_name.unlink()
-        except Exception as e:
-            print(data[:10])
-            print(file_name)
-            raise e
+    workers.map(parse_srx, work)
 
 
 def parse_table(data, srx):
     df = pd.read_table(data, index_col=0, squeeze=True).astype(np.uint32).to_frame().T
     df.index = pd.Index([srx], name="srx")
     return df
+
+
+def parse_srx(files):
+    # Check if file is from feature counts or is already parsed.
+    with files.file_name.open() as fh:
+        data = fh.read(10)
+
+    if data.startswith("#"):
+        df = parse_featureCounts_counts(files.file_name, files.srx)
+    else:
+        df = parse_table(files.file_name, files.srx)
+
+    df.to_parquet(files.output)
+    files.file_name.unlink()
 
 
 if __name__ == "__main__":

--- a/migration/rnaseq-wf_fusion_counts.py
+++ b/migration/rnaseq-wf_fusion_counts.py
@@ -10,7 +10,6 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
-CLEAN_UP = os.environ.get("CLEAN_UP", False)
 THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 
@@ -57,8 +56,6 @@ def parse_srx(files):
         df = parse_table(files.file_name, files.srx)
 
     df.to_parquet(files.output)
-    if CLEAN_UP:
-        files.file_name.unlink()
 
 
 if __name__ == "__main__":

--- a/migration/rnaseq-wf_fusion_counts.py
+++ b/migration/rnaseq-wf_fusion_counts.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, "../src")
+from ncbi_remap.parser import parse_featureCounts_counts
+
+
+def main():
+    for srx_pth in Path("../output/rnaseq-wf/samples").iterdir():
+        if not srx_pth.is_dir():
+            continue
+
+        srx = srx_pth.name
+        file_name = srx_pth / f"{srx}.bam.exon_fusions.counts"
+        output = f"../output/rnaseq-wf/fusion_counts/{srx}.parquet"
+
+        if not file_name.exists():
+            continue
+
+        try:
+            # Check if file is from feature counts or is already parsed.
+            with file_name.open() as fh:
+                data = fh.read(10)
+
+            if data.startswith("#"):
+                df = parse_featureCounts_counts(file_name, srx)
+            else:
+                df = parse_table(file_name, srx)
+
+            df.to_parquet(output)
+            file_name.unlink()
+        except Exception as e:
+            print(data[:10])
+            print(file_name)
+            raise e
+
+
+def parse_table(data, srx):
+    df = pd.read_table(data, index_col=0, squeeze=True).astype(np.uint32).to_frame().T
+    df.index = pd.Index([srx], name="srx")
+    return df
+
+
+if __name__ == "__main__":
+    main()

--- a/migration/rnaseq-wf_fusion_counts.py
+++ b/migration/rnaseq-wf_fusion_counts.py
@@ -10,6 +10,7 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
+CLEAN_UP = False
 THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 
@@ -56,7 +57,8 @@ def parse_srx(files):
         df = parse_table(files.file_name, files.srx)
 
     df.to_parquet(files.output)
-    files.file_name.unlink()
+    if CLEAN_UP:
+        files.file_name.unlink()
 
 
 if __name__ == "__main__":

--- a/migration/rnaseq-wf_fusion_counts.py
+++ b/migration/rnaseq-wf_fusion_counts.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 from collections import namedtuple
@@ -9,11 +10,12 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
+THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 
 
 def main():
-    workers = Pool(24)
+    workers = Pool(THREADS)
     work = []
     for srx_pth in Path("../output/rnaseq-wf/samples").iterdir():
         srx = srx_pth.name

--- a/migration/rnaseq-wf_fusion_counts.py
+++ b/migration/rnaseq-wf_fusion_counts.py
@@ -10,7 +10,7 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
-CLEAN_UP = False
+CLEAN_UP = os.environ.get("CLEAN_UP", False)
 THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 

--- a/migration/rnaseq-wf_fusion_counts.py
+++ b/migration/rnaseq-wf_fusion_counts.py
@@ -33,8 +33,13 @@ def main():
 
 
 def parse_table(data, srx):
-    df = pd.read_table(data, index_col=0, squeeze=True).astype(np.uint32).to_frame().T
-    df.index = pd.Index([srx], name="srx")
+    header = pd.read_table(data, nrows=1).columns
+    df = (
+        pd.read_table(data, dtype={header[1]: np.uint32})
+        .rename(columns={header[0]: "FBgn", header[1]: "count"})
+        .assign(srx=srx)
+        .set_index(["srx", "FBgn"])
+    )
     return df
 
 

--- a/migration/rnaseq-wf_gene_counts.py
+++ b/migration/rnaseq-wf_gene_counts.py
@@ -10,7 +10,6 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
-CLEAN_UP = os.environ.get("CLEAN_UP", False)
 THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 
@@ -57,8 +56,6 @@ def parse_srx(files):
         df = parse_table(files.file_name, files.srx)
 
     df.to_parquet(files.output)
-    if CLEAN_UP:
-        files.file_name.unlink()
 
 
 if __name__ == "__main__":

--- a/migration/rnaseq-wf_gene_counts.py
+++ b/migration/rnaseq-wf_gene_counts.py
@@ -10,6 +10,7 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
+CLEAN_UP = False
 THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 
@@ -56,7 +57,8 @@ def parse_srx(files):
         df = parse_table(files.file_name, files.srx)
 
     df.to_parquet(files.output)
-    files.file_name.unlink()
+    if CLEAN_UP:
+        files.file_name.unlink()
 
 
 if __name__ == "__main__":

--- a/migration/rnaseq-wf_gene_counts.py
+++ b/migration/rnaseq-wf_gene_counts.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
-from io import StringIO
+from collections import namedtuple
+from multiprocessing import Pool
 
 import numpy as np
 import pandas as pd
@@ -8,41 +9,47 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
+Files = namedtuple("Files", "srx file_name output")
+
 
 def main():
+    workers = Pool(24)
+    work = []
     for srx_pth in Path("../output/rnaseq-wf/samples").iterdir():
+        srx = srx_pth.name
         if not srx_pth.is_dir():
             continue
 
-        srx = srx_pth.name
-        file_name = srx_pth / f"{srx}.bam.counts"
-        output = f"../output/rnaseq-wf/gene_counts/{srx}.parquet"
+        files = Files(
+            srx,
+            srx_pth / f"{srx}.bam.counts",
+            f"../output/rnaseq-wf/gene_counts/{srx}.parquet",
+        )
 
-        if not file_name.exists():
-            continue
+        if files.file_name.exists():
+            work.append(files)
 
-        try:
-            # Check if file is from feature counts or is already parsed.
-            with file_name.open() as fh:
-                data = fh.read(10)
-
-            if data.startswith("#"):
-                df = parse_featureCounts_counts(file_name, srx)
-            else:
-                df = parse_table(file_name, srx)
-
-            df.to_parquet(output)
-            file_name.unlink()
-        except Exception as e:
-            print(data[:10])
-            print(file_name)
-            raise e
+    workers.map(parse_srx, work)
 
 
 def parse_table(data, srx):
     df = pd.read_table(data, index_col=0, squeeze=True).astype(np.uint32).to_frame().T
     df.index = pd.Index([srx], name="srx")
     return df
+
+
+def parse_srx(files):
+    # Check if file is from feature counts or is already parsed.
+    with files.file_name.open() as fh:
+        data = fh.read(10)
+
+    if data.startswith("#"):
+        df = parse_featureCounts_counts(files.file_name, files.srx)
+    else:
+        df = parse_table(files.file_name, files.srx)
+
+    df.to_parquet(files.output)
+    files.file_name.unlink()
 
 
 if __name__ == "__main__":

--- a/migration/rnaseq-wf_gene_counts.py
+++ b/migration/rnaseq-wf_gene_counts.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 from collections import namedtuple
@@ -9,11 +10,12 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
+THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 
 
 def main():
-    workers = Pool(24)
+    workers = Pool(THREADS)
     work = []
     for srx_pth in Path("../output/rnaseq-wf/samples").iterdir():
         srx = srx_pth.name

--- a/migration/rnaseq-wf_gene_counts.py
+++ b/migration/rnaseq-wf_gene_counts.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+from io import StringIO
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, "../src")
+from ncbi_remap.parser import parse_featureCounts_counts
+
+
+def main():
+    for srx_pth in Path("../output/rnaseq-wf/samples").iterdir():
+        if not srx_pth.is_dir():
+            continue
+
+        srx = srx_pth.name
+        file_name = srx_pth / f"{srx}.bam.counts"
+        output = f"../output/rnaseq-wf/gene_counts/{srx}.parquet"
+
+        if not file_name.exists():
+            continue
+
+        try:
+            # Check if file is from feature counts or is already parsed.
+            with file_name.open() as fh:
+                data = fh.read(10)
+
+            if data.startswith("#"):
+                df = parse_featureCounts_counts(file_name, srx)
+            else:
+                df = parse_table(file_name, srx)
+
+            df.to_parquet(output)
+            file_name.unlink()
+        except Exception as e:
+            print(data[:10])
+            print(file_name)
+            raise e
+
+
+def parse_table(data, srx):
+    df = pd.read_table(data, index_col=0, squeeze=True).astype(np.uint32).to_frame().T
+    df.index = pd.Index([srx], name="srx")
+    return df
+
+
+if __name__ == "__main__":
+    main()

--- a/migration/rnaseq-wf_gene_counts.py
+++ b/migration/rnaseq-wf_gene_counts.py
@@ -10,7 +10,7 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
-CLEAN_UP = False
+CLEAN_UP = os.environ.get("CLEAN_UP", False)
 THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 

--- a/migration/rnaseq-wf_gene_counts.py
+++ b/migration/rnaseq-wf_gene_counts.py
@@ -33,8 +33,13 @@ def main():
 
 
 def parse_table(data, srx):
-    df = pd.read_table(data, index_col=0, squeeze=True).astype(np.uint32).to_frame().T
-    df.index = pd.Index([srx], name="srx")
+    header = pd.read_table(data, nrows=1).columns
+    df = (
+        pd.read_table(data, dtype={header[1]: np.uint32})
+        .rename(columns={header[0]: "FBgn", header[1]: "count"})
+        .assign(srx=srx)
+        .set_index(["srx", "FBgn"])
+    )
     return df
 
 

--- a/migration/rnaseq-wf_hisat2.py
+++ b/migration/rnaseq-wf_hisat2.py
@@ -1,0 +1,88 @@
+import sys
+from collections import namedtuple
+from pathlib import Path
+import shutil
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, "../src")
+from ncbi_remap.parser import parse_hisat2
+
+RNASEQ_PATH = Path("../output/rnaseq-wf/samples")
+
+Files = namedtuple("Files", "srr idx log bam bai output")
+
+
+class Hisat2Exception(Exception):
+    """Basic exception when there are problems running Atropos"""
+
+
+def main():
+    for srr_pth in RNASEQ_PATH.glob("**/SRR*"):
+
+        if not srr_pth.is_dir():
+            continue
+
+        srr = srr_pth.name
+        files = Files(
+            srr,
+            pd.Index([srr], name="srr"),
+            (srr_pth / f"{srr}.fq.bam.log"),
+            (srr_pth / f"{srr}.fq.bam"),
+            (srr_pth / f"{srr}.fq.bam.bai"),
+            f"../output/rnaseq-wf/hisat2/{srr}.parquet",
+        )
+        if files.log.exists():
+            convert_log(files)
+            Path(files.log).unlink()
+
+    remove_alignment_bad()
+
+
+def convert_log(files):
+    try:
+        try:
+            df = pd.read_table(files.log, index_col=[0, 1]).reset_index(drop=True).fillna(0)
+        except IndexError:
+            df = parse_hisat2(files.log).fillna(0)
+        except pd.errors.EmptyDataError:
+            raise Hisat2Exception
+
+        if (df == 0).all().all():
+            raise Hisat2Exception
+
+        df.index = pd.Index([files.srr], name="srr")
+        df.to_parquet(files.output)
+
+        uniquely_aligned = (
+            df.iloc[0, :]["num_concordant_reads_uniquely_aligned"]
+            + df.iloc[0, :]["num_uniquely_aligned"]
+        )
+
+        if (df.iloc[0, :]["per_alignment"] < 1) | (uniquely_aligned < 1000):
+            raise Hisat2Exception
+
+    except Hisat2Exception:
+        alignment_bad_path = Path("../output/rnaseq-wf/alignment_bad")
+        alignment_bad_path.mkdir(exist_ok=True)
+        Path(alignment_bad_path, files.srr).touch()
+
+        if Path(files.bam).exists():
+            Path(files.bam).unlink()
+
+        if Path(files.bai).exists():
+            Path(files.bai).unlink()
+
+
+def remove_alignment_bad():
+    srrs = set([pth.name for pth in Path("../output/rnaseq-wf/alignment_bad").iterdir()])
+    for pth in Path("../output/rnaseq-wf/samples/").glob("**/SRR*"):
+        if pth.name in srrs:
+            for file_pth in pth.iterdir():
+                if not "fastq_screen" in file_pth.name:
+                    file_pth.unlink()
+
+
+if __name__ == "__main__":
+    main()

--- a/migration/rnaseq-wf_hisat2.py
+++ b/migration/rnaseq-wf_hisat2.py
@@ -9,6 +9,7 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_hisat2
 
+CLEAN_UP = False
 RNASEQ_PATH = Path("../output/rnaseq-wf/samples")
 
 Files = namedtuple("Files", "srr idx log bam bai output")
@@ -35,7 +36,8 @@ def main():
         )
         if files.log.exists():
             convert_log(files)
-            Path(files.log).unlink()
+            if CLEAN_UP:
+                Path(files.log).unlink()
 
     remove_alignment_bad()
 
@@ -68,10 +70,10 @@ def convert_log(files):
         alignment_bad_path.mkdir(exist_ok=True)
         Path(alignment_bad_path, files.srr).touch()
 
-        if Path(files.bam).exists():
+        if Path(files.bam).exists() and CLEAN_UP:
             Path(files.bam).unlink()
 
-        if Path(files.bai).exists():
+        if Path(files.bai).exists() and CLEAN_UP:
             Path(files.bai).unlink()
 
 
@@ -80,7 +82,7 @@ def remove_alignment_bad():
     for pth in Path("../output/rnaseq-wf/samples/").glob("**/SRR*"):
         if pth.name in srrs:
             for file_pth in pth.iterdir():
-                if not "fastq_screen" in file_pth.name:
+                if not "fastq_screen" in file_pth.name and CLEAN_UP:
                     file_pth.unlink()
 
 

--- a/migration/rnaseq-wf_hisat2.py
+++ b/migration/rnaseq-wf_hisat2.py
@@ -1,15 +1,14 @@
 import sys
+import os
 from collections import namedtuple
 from pathlib import Path
-import shutil
 
-import numpy as np
 import pandas as pd
 
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_hisat2
 
-CLEAN_UP = False
+CLEAN_UP = os.environ.get("CLEAN_UP", False)
 RNASEQ_PATH = Path("../output/rnaseq-wf/samples")
 
 Files = namedtuple("Files", "srr idx log bam bai output")

--- a/migration/rnaseq-wf_hisat2.py
+++ b/migration/rnaseq-wf_hisat2.py
@@ -1,5 +1,4 @@
 import sys
-import os
 from collections import namedtuple
 from pathlib import Path
 
@@ -8,7 +7,6 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_hisat2
 
-CLEAN_UP = os.environ.get("CLEAN_UP", False)
 RNASEQ_PATH = Path("../output/rnaseq-wf/samples")
 
 Files = namedtuple("Files", "srr idx log bam bai output")
@@ -35,10 +33,6 @@ def main():
         )
         if files.log.exists():
             convert_log(files)
-            if CLEAN_UP:
-                Path(files.log).unlink()
-
-    remove_alignment_bad()
 
 
 def convert_log(files):
@@ -68,21 +62,6 @@ def convert_log(files):
         alignment_bad_path = Path("../output/rnaseq-wf/alignment_bad")
         alignment_bad_path.mkdir(exist_ok=True)
         Path(alignment_bad_path, files.srr).touch()
-
-        if Path(files.bam).exists() and CLEAN_UP:
-            Path(files.bam).unlink()
-
-        if Path(files.bai).exists() and CLEAN_UP:
-            Path(files.bai).unlink()
-
-
-def remove_alignment_bad():
-    srrs = set([pth.name for pth in Path("../output/rnaseq-wf/alignment_bad").iterdir()])
-    for pth in Path("../output/rnaseq-wf/samples/").glob("**/SRR*"):
-        if pth.name in srrs:
-            for file_pth in pth.iterdir():
-                if not "fastq_screen" in file_pth.name and CLEAN_UP:
-                    file_pth.unlink()
 
 
 if __name__ == "__main__":

--- a/migration/rnaseq-wf_intergenic_counts.py
+++ b/migration/rnaseq-wf_intergenic_counts.py
@@ -1,5 +1,7 @@
 import sys
 from pathlib import Path
+from collections import namedtuple
+from multiprocessing import Pool
 
 import numpy as np
 import pandas as pd
@@ -7,41 +9,47 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
+Files = namedtuple("Files", "srx file_name output")
+
 
 def main():
+    workers = Pool(24)
+    work = []
     for srx_pth in Path("../output/rnaseq-wf/samples").iterdir():
+        srx = srx_pth.name
         if not srx_pth.is_dir():
             continue
 
-        srx = srx_pth.name
-        file_name = srx_pth / f"{srx}.bam.intergenic.counts"
-        output = f"../output/rnaseq-wf/intergenic_counts/{srx}.parquet"
+        files = Files(
+            srx,
+            srx_pth / f"{srx}.bam.intergenic.counts",
+            f"../output/rnaseq-wf/intergenic_counts/{srx}.parquet"
+        )
 
-        if not file_name.exists():
-            continue
+        if files.file_name.exists():
+            work.append(files)
 
-        try:
-            # Check if file is from feature counts or is already parsed.
-            with file_name.open() as fh:
-                data = fh.read(10)
-
-            if data.startswith("#"):
-                df = parse_featureCounts_counts(file_name, srx)
-            else:
-                df = parse_table(file_name, srx)
-
-            df.to_parquet(output)
-            file_name.unlink()
-        except Exception as e:
-            print(data[:10])
-            print(file_name)
-            raise e
+    workers.map(parse_srx, work)
 
 
 def parse_table(data, srx):
     df = pd.read_table(data, index_col=0, squeeze=True).astype(np.uint32).to_frame().T
     df.index = pd.Index([srx], name="srx")
     return df
+
+
+def parse_srx(files):
+    # Check if file is from feature counts or is already parsed.
+    with files.file_name.open() as fh:
+        data = fh.read(10)
+
+    if data.startswith("#"):
+        df = parse_featureCounts_counts(files.file_name, files.srx)
+    else:
+        df = parse_table(files.file_name, files.srx)
+
+    df.to_parquet(files.output)
+    files.file_name.unlink()
 
 
 if __name__ == "__main__":

--- a/migration/rnaseq-wf_intergenic_counts.py
+++ b/migration/rnaseq-wf_intergenic_counts.py
@@ -10,7 +10,6 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
-CLEAN_UP = os.environ.get("CLEAN_UP", False)
 THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 
@@ -57,8 +56,6 @@ def parse_srx(files):
         df = parse_table(files.file_name, files.srx)
 
     df.to_parquet(files.output)
-    if CLEAN_UP:
-        files.file_name.unlink()
 
 
 if __name__ == "__main__":

--- a/migration/rnaseq-wf_intergenic_counts.py
+++ b/migration/rnaseq-wf_intergenic_counts.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, "../src")
+from ncbi_remap.parser import parse_featureCounts_counts
+
+
+def main():
+    for srx_pth in Path("../output/rnaseq-wf/samples").iterdir():
+        if not srx_pth.is_dir():
+            continue
+
+        srx = srx_pth.name
+        file_name = srx_pth / f"{srx}.bam.intergenic.counts"
+        output = f"../output/rnaseq-wf/intergenic_counts/{srx}.parquet"
+
+        if not file_name.exists():
+            continue
+
+        try:
+            # Check if file is from feature counts or is already parsed.
+            with file_name.open() as fh:
+                data = fh.read(10)
+
+            if data.startswith("#"):
+                df = parse_featureCounts_counts(file_name, srx)
+            else:
+                df = parse_table(file_name, srx)
+
+            df.to_parquet(output)
+            file_name.unlink()
+        except Exception as e:
+            print(data[:10])
+            print(file_name)
+            raise e
+
+
+def parse_table(data, srx):
+    df = pd.read_table(data, index_col=0, squeeze=True).astype(np.uint32).to_frame().T
+    df.index = pd.Index([srx], name="srx")
+    return df
+
+
+if __name__ == "__main__":
+    main()

--- a/migration/rnaseq-wf_intergenic_counts.py
+++ b/migration/rnaseq-wf_intergenic_counts.py
@@ -10,6 +10,7 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
+CLEAN_UP = False
 THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 
@@ -56,7 +57,8 @@ def parse_srx(files):
         df = parse_table(files.file_name, files.srx)
 
     df.to_parquet(files.output)
-    files.file_name.unlink()
+    if CLEAN_UP:
+        files.file_name.unlink()
 
 
 if __name__ == "__main__":

--- a/migration/rnaseq-wf_intergenic_counts.py
+++ b/migration/rnaseq-wf_intergenic_counts.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 from collections import namedtuple
@@ -9,11 +10,12 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
+THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 
 
 def main():
-    workers = Pool(24)
+    workers = Pool(THREADS)
     work = []
     for srx_pth in Path("../output/rnaseq-wf/samples").iterdir():
         srx = srx_pth.name

--- a/migration/rnaseq-wf_intergenic_counts.py
+++ b/migration/rnaseq-wf_intergenic_counts.py
@@ -10,7 +10,7 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
-CLEAN_UP = False
+CLEAN_UP = os.environ.get("CLEAN_UP", False)
 THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 

--- a/migration/rnaseq-wf_intergenic_counts.py
+++ b/migration/rnaseq-wf_intergenic_counts.py
@@ -33,8 +33,13 @@ def main():
 
 
 def parse_table(data, srx):
-    df = pd.read_table(data, index_col=0, squeeze=True).astype(np.uint32).to_frame().T
-    df.index = pd.Index([srx], name="srx")
+    header = pd.read_table(data, nrows=1).columns
+    df = (
+        pd.read_table(data, dtype={header[1]: np.uint32})
+        .rename(columns={header[0]: "FBgn", header[1]: "count"})
+        .assign(srx=srx)
+        .set_index(["srx", "FBgn"])
+    )
     return df
 
 

--- a/migration/rnaseq-wf_junction_counts.py
+++ b/migration/rnaseq-wf_junction_counts.py
@@ -7,7 +7,7 @@ from multiprocessing import Pool
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_jcounts
 
-CLEAN_UP = False
+CLEAN_UP = os.environ.get("CLEAN_UP", False)
 THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 

--- a/migration/rnaseq-wf_junction_counts.py
+++ b/migration/rnaseq-wf_junction_counts.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, "../src")
+from ncbi_remap.parser import parse_featureCounts_jcounts
+
+
+def main():
+    for srx_pth in Path("../output/rnaseq-wf/samples").iterdir():
+        if not srx_pth.is_dir():
+            continue
+
+        srx = srx_pth.name
+        file_name = srx_pth / f"{srx}.bam.counts.jcounts"
+        output = f"../output/rnaseq-wf/junction_counts/{srx}.parquet"
+
+        if not file_name.exists():
+            continue
+
+        try:
+            df = parse_featureCounts_jcounts(file_name, srx)
+            df.to_parquet(output)
+            file_name.unlink()
+        except Exception as e:
+            print(file_name)
+            raise e
+
+
+if __name__ == "__main__":
+    main()

--- a/migration/rnaseq-wf_junction_counts.py
+++ b/migration/rnaseq-wf_junction_counts.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 from collections import namedtuple
@@ -6,10 +7,11 @@ from multiprocessing import Pool
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_jcounts
 
+THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 
 def main():
-    workers = Pool(24)
+    workers = Pool(THREADS)
     work = []
     for srx_pth in Path("../output/rnaseq-wf/samples").iterdir():
         srx = srx_pth.name

--- a/migration/rnaseq-wf_junction_counts.py
+++ b/migration/rnaseq-wf_junction_counts.py
@@ -7,7 +7,6 @@ from multiprocessing import Pool
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_jcounts
 
-CLEAN_UP = os.environ.get("CLEAN_UP", False)
 THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 
@@ -34,8 +33,6 @@ def main():
 def parse_srx(files):
     df = parse_featureCounts_jcounts(files.file_name, files.srx)
     df.to_parquet(files.output)
-    if CLEAN_UP:
-        files.file_name.unlink()
 
 
 if __name__ == "__main__":

--- a/migration/rnaseq-wf_junction_counts.py
+++ b/migration/rnaseq-wf_junction_counts.py
@@ -7,6 +7,7 @@ from multiprocessing import Pool
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_jcounts
 
+CLEAN_UP = False
 THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 
@@ -33,7 +34,8 @@ def main():
 def parse_srx(files):
     df = parse_featureCounts_jcounts(files.file_name, files.srx)
     df.to_parquet(files.output)
-    files.file_name.unlink()
+    if CLEAN_UP:
+        files.file_name.unlink()
 
 
 if __name__ == "__main__":

--- a/migration/rnaseq-wf_prep.py
+++ b/migration/rnaseq-wf_prep.py
@@ -22,10 +22,9 @@ import shutil
 def main():
     remove_non_rnaseq()
 
-    clear_folder("../output/rnaseq-wf/alignment_bad")
-    clear_folder("../output/rnaseq-wf/atropos_bad")
-    clear_folder("../output/rnaseq-wf/done")
-
+    create_folder("../output/rnaseq-wf/alignment_bad")
+    create_folder("../output/rnaseq-wf/atropos_bad")
+    create_folder("../output/rnaseq-wf/done")
     create_folder("../output/rnaseq-wf/atropos")
     create_folder("../output/rnaseq-wf/hisat2")
     create_folder("../output/rnaseq-wf/aln_stats")
@@ -36,6 +35,10 @@ def main():
     create_folder("../output/rnaseq-wf/fusion_counts")
     create_folder("../output/rnaseq-wf/flybase_bigwigs")
     create_folder("../output/rnaseq-wf/ucsc_bigwigs")
+
+    clear_folder("../output/rnaseq-wf/alignment_bad")
+    clear_folder("../output/rnaseq-wf/atropos_bad")
+    clear_folder("../output/rnaseq-wf/done")
 
     cleanup_special_cases()
 

--- a/migration/rnaseq-wf_prep.py
+++ b/migration/rnaseq-wf_prep.py
@@ -1,0 +1,81 @@
+"""Prep for RNA-Seq migration.
+
+* Removes samples that are not in rnaseq.pkl
+
+* Clears folder contents
+    * ../output/rnaseq-wf/alignment_bad 
+    * ../output/rnaseq-wf/atropos_bad
+    * ../output/rnaseq-wf/done
+
+* Creates directories
+    * ../output/rnaseq-wf/atropos
+    * ../output/rnaseq-wf/hisat2
+    * ../output/rnaseq-wf/aln_stats
+    * ../output/rnaseq-wf/{gene,junction,intergenic,segment,fusion}_counts
+    * ../output/rnaseq-wf/{flybase,ucsc}_bigwigs
+"""
+import pickle
+from pathlib import Path
+import shutil
+
+
+def main():
+    remove_non_rnaseq()
+
+    clear_folder("../output/rnaseq-wf/alignment_bad")
+    clear_folder("../output/rnaseq-wf/atropos_bad")
+    clear_folder("../output/rnaseq-wf/done")
+
+    create_folder("../output/rnaseq-wf/atropos")
+    create_folder("../output/rnaseq-wf/hisat2")
+    create_folder("../output/rnaseq-wf/aln_stats")
+    create_folder("../output/rnaseq-wf/gene_counts")
+    create_folder("../output/rnaseq-wf/junction_counts")
+    create_folder("../output/rnaseq-wf/intergenic_counts")
+    create_folder("../output/rnaseq-wf/segment_counts")
+    create_folder("../output/rnaseq-wf/fusion_counts")
+    create_folder("../output/rnaseq-wf/flybase_bigwigs")
+    create_folder("../output/rnaseq-wf/ucsc_bigwigs")
+
+    cleanup_special_cases()
+
+def remove_path(file_name):
+    pth = Path(file_name)
+    if pth.exists() and pth.is_file():
+        pth.unlink()
+
+def remove_folder(folder_name):
+    pth = Path(folder_name)
+    if pth.exists():
+        shutil.rmtree(pth)
+
+def remove_non_rnaseq():
+    rnaseq = pickle.load(open("../output/library_strategy-wf/rnaseq.pkl", "rb"))
+    workflow = {x.name for x in Path("../output/rnaseq-wf/samples").iterdir()}
+    not_rnaseq = workflow - rnaseq
+    for srx in not_rnaseq:
+        remove_folder(f"../output/rnaseq-wf/samples/{srx}")
+
+
+def clear_folder(folder_name):
+    pth = Path(folder_name)
+    for item in pth.iterdir():
+        if item.is_file():
+            item.unlink()
+        else:
+            print("This is not a file", item, sep="\t")
+
+
+def create_folder(folder_name):
+    pth = Path(folder_name)
+    pth.mkdir(exist_ok=True)
+
+
+def cleanup_special_cases():
+    # Empty junction counts
+    remove_folder("../output/rnaseq-wf/samples/SRX019645")
+
+
+
+if __name__ == "__main__":
+    main()

--- a/migration/rnaseq-wf_segment_counts.py
+++ b/migration/rnaseq-wf_segment_counts.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, "../src")
+from ncbi_remap.parser import parse_featureCounts_counts
+
+
+def main():
+    for srx_pth in Path("../output/rnaseq-wf/samples").iterdir():
+        if not srx_pth.is_dir():
+            continue
+
+        srx = srx_pth.name
+        file_name = srx_pth / f"{srx}.bam.exon_segments.counts"
+        output = f"../output/rnaseq-wf/segment_counts/{srx}.parquet"
+
+        if not file_name.exists():
+            continue
+
+        try:
+            # Check if file is from feature counts or is already parsed.
+            with file_name.open() as fh:
+                data = fh.read(10)
+
+            if data.startswith("#"):
+                df = parse_featureCounts_counts(file_name, srx)
+            else:
+                df = parse_table(file_name, srx)
+
+            df.to_parquet(output)
+
+            # file_name.unlink()
+        except Exception as e:
+            print(data[:10])
+            print(file_name)
+            raise e
+
+
+def parse_table(data, srx):
+    df = pd.read_table(data, index_col=0, squeeze=True).astype(np.uint32).to_frame().T
+    df.index = pd.Index([srx], name="srx")
+    return df
+
+
+if __name__ == "__main__":
+    main()

--- a/migration/rnaseq-wf_segment_counts.py
+++ b/migration/rnaseq-wf_segment_counts.py
@@ -10,7 +10,6 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
-CLEAN_UP = os.environ.get("CLEAN_UP", False)
 THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 
@@ -57,8 +56,6 @@ def parse_srx(files):
         df = parse_table(files.file_name, files.srx)
 
     df.to_parquet(files.output)
-    if CLEAN_UP:
-        files.file_name.unlink()
 
 
 if __name__ == "__main__":

--- a/migration/rnaseq-wf_segment_counts.py
+++ b/migration/rnaseq-wf_segment_counts.py
@@ -1,5 +1,7 @@
 import sys
 from pathlib import Path
+from collections import namedtuple
+from multiprocessing import Pool
 
 import numpy as np
 import pandas as pd
@@ -7,42 +9,47 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
+Files = namedtuple("Files", "srx file_name output")
+
 
 def main():
+    workers = Pool(24)
+    work = []
     for srx_pth in Path("../output/rnaseq-wf/samples").iterdir():
+        srx = srx_pth.name
         if not srx_pth.is_dir():
             continue
 
-        srx = srx_pth.name
-        file_name = srx_pth / f"{srx}.bam.exon_segments.counts"
-        output = f"../output/rnaseq-wf/segment_counts/{srx}.parquet"
+        files = Files(
+            srx,
+            srx_pth / f"{srx}.bam.exon_segments.counts",
+            f"../output/rnaseq-wf/segment_counts/{srx}.parquet"
+        )
 
-        if not file_name.exists():
-            continue
+        if files.file_name.exists():
+            work.append(files)
 
-        try:
-            # Check if file is from feature counts or is already parsed.
-            with file_name.open() as fh:
-                data = fh.read(10)
-
-            if data.startswith("#"):
-                df = parse_featureCounts_counts(file_name, srx)
-            else:
-                df = parse_table(file_name, srx)
-
-            df.to_parquet(output)
-
-            # file_name.unlink()
-        except Exception as e:
-            print(data[:10])
-            print(file_name)
-            raise e
+    workers.map(parse_srx, work)
 
 
 def parse_table(data, srx):
     df = pd.read_table(data, index_col=0, squeeze=True).astype(np.uint32).to_frame().T
     df.index = pd.Index([srx], name="srx")
     return df
+
+
+def parse_srx(files):
+    # Check if file is from feature counts or is already parsed.
+    with files.file_name.open() as fh:
+        data = fh.read(10)
+
+    if data.startswith("#"):
+        df = parse_featureCounts_counts(files.file_name, files.srx)
+    else:
+        df = parse_table(files.file_name, files.srx)
+
+    df.to_parquet(files.output)
+    files.file_name.unlink()
 
 
 if __name__ == "__main__":

--- a/migration/rnaseq-wf_segment_counts.py
+++ b/migration/rnaseq-wf_segment_counts.py
@@ -10,6 +10,7 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
+CLEAN_UP = False
 THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 
@@ -56,7 +57,8 @@ def parse_srx(files):
         df = parse_table(files.file_name, files.srx)
 
     df.to_parquet(files.output)
-    files.file_name.unlink()
+    if CLEAN_UP:
+        files.file_name.unlink()
 
 
 if __name__ == "__main__":

--- a/migration/rnaseq-wf_segment_counts.py
+++ b/migration/rnaseq-wf_segment_counts.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 from collections import namedtuple
@@ -9,11 +10,12 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
+THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 
 
 def main():
-    workers = Pool(24)
+    workers = Pool(THREADS)
     work = []
     for srx_pth in Path("../output/rnaseq-wf/samples").iterdir():
         srx = srx_pth.name

--- a/migration/rnaseq-wf_segment_counts.py
+++ b/migration/rnaseq-wf_segment_counts.py
@@ -10,7 +10,7 @@ import pandas as pd
 sys.path.insert(0, "../src")
 from ncbi_remap.parser import parse_featureCounts_counts
 
-CLEAN_UP = False
+CLEAN_UP = os.environ.get("CLEAN_UP", False)
 THREADS = int(os.environ.get("SLURM_CPUS_PER_TASK", "2"))
 Files = namedtuple("Files", "srx file_name output")
 

--- a/migration/rnaseq-wf_segment_counts.py
+++ b/migration/rnaseq-wf_segment_counts.py
@@ -33,8 +33,13 @@ def main():
 
 
 def parse_table(data, srx):
-    df = pd.read_table(data, index_col=0, squeeze=True).astype(np.uint32).to_frame().T
-    df.index = pd.Index([srx], name="srx")
+    header = pd.read_table(data, nrows=1).columns
+    df = (
+        pd.read_table(data, dtype={header[1]: np.uint32})
+        .rename(columns={header[0]: "FBgn", header[1]: "count"})
+        .assign(srx=srx)
+        .set_index(["srx", "FBgn"])
+    )
     return df
 
 


### PR DESCRIPTION
### What does it do?
- Migrates RNA-Seq workflow files to new layout.

For aggregation, I have found the easiest solution that integrates well with workflow tools is storing multiple parquet files in a folder. Parquet can easily read an entire folder of files and can do things like column filtering in C. While a database would be quicker, it is harder to track additions with a file-based workflow system like Snakemake.

